### PR TITLE
Dependencies for right order loading assets

### DIFF
--- a/DateRangePickerAsset.php
+++ b/DateRangePickerAsset.php
@@ -6,6 +6,11 @@ use yii\web\AssetBundle;
 
 class DateRangePickerAsset extends AssetBundle
 {
+	public $depends    = [
+		'yii\web\JqueryAsset',
+		'yii\bootstrap\BootstrapAsset',
+	];
+
 	public function init()
 	{
 		$this->sourcePath = __DIR__ . '/assets';


### PR DESCRIPTION
Sometimes widget load it assets before jquery loads. Registering dependencies help to avoid this situation
